### PR TITLE
Made TextField in CreatePasswordView a SecureField

### DIFF
--- a/Shared/Views/LockView/LockView+CreatePassword.swift
+++ b/Shared/Views/LockView/LockView+CreatePassword.swift
@@ -17,7 +17,7 @@ extension LockView {
                 Text("Welcome to OpenSesame")
                     .font(.title.bold())
                 GroupBox {
-                    TextField("Enter a new master password", text: $password, onCommit: {
+					SecureField("Enter a new master password", text: $password, onCommit: {
                         guard !password.isEmpty else { return }
                         completionAction(password)
                     })


### PR DESCRIPTION
Inside CreatePasswordView (where you set a new master password), the password wasn't hidden (you could see it as you type). I changed it to a SecureField (in case it wasn't intentional).