### PR TITLE
Fix Toolbar Appearance on macOS

### DIFF
--- a/Shared/Views/ContentView/ContentView+List.swift
+++ b/Shared/Views/ContentView/ContentView+List.swift
@@ -10,6 +10,15 @@ import CoreData
 import StoreKit
 
 extension ContentView {
+    
+    var lockButton: some View {
+        Button {
+            isLocked = true
+        } label: {
+            Label("Lock", systemImage: "lock.fill")
+        }
+    }
+    
     var list: some View {
         List {
             vaultSection
@@ -18,14 +27,9 @@ extension ContentView {
         }
         .listStyle(.sidebar)
         .toolbar {
+#if os(iOS)
             ToolbarItem(placement: ToolbarItemPlacement.navigation) {
                 HStack {
-                    Button {
-                        isLocked = true
-                    } label: {
-                        Label("Lock", systemImage: "lock.fill")
-                    }
-#if os(iOS)
                     Button {
                         showSettings.toggle()
                     } label: {
@@ -44,9 +48,9 @@ extension ContentView {
                                 }
                         }
                     }
-#endif
                 }
             }
+#endif
 #if os(iOS)
             ToolbarItem(placement: .navigationBarTrailing) {
                 EditButton()
@@ -158,6 +162,9 @@ extension ContentView {
                 } else {
                     NavigationLink(tag: vault, selection: $selectedVault) {
                         VaultView(vault: vault)
+                            .toolbar {ToolbarItem(placement: .navigation) {
+                                lockButton
+                            }}
                     } label: {
                         Label(vault.name!.capitalized, systemImage: "lock.square.stack.fill")
                     }

--- a/Shared/Views/ContentView/ContentView.swift
+++ b/Shared/Views/ContentView/ContentView.swift
@@ -82,6 +82,7 @@ struct ContentView: View {
                     .listStyle(.inset(alternatesRowBackgrounds: true))
 #endif
                     EmptyView()
+                        .toolbar {ToolbarItem {Spacer()}}
                 }
             } else {
                 NavigationView {


### PR DESCRIPTION
The toolbar in the supplementary view does not display correctly. 

The standard macOS appearance (as seen in apps such as Mail.app and Xcode 13) is to have separate sections in the toolbar for each view in the NavigationView. In OpenSesame, the toolbar appears as one continuous section (aside from the sidebar).

Current TestFlight Build:
<img width="858" alt="Screen Shot 2021-10-06 at 6 52 59 PM" src="https://user-images.githubusercontent.com/49624366/136296289-db20fee8-6473-40e4-937b-40cdb3203b50.png">


This PR Fixes that issue, giving the Toolbar the expected macOS appearance. Note that you may have to adjust the password list's width in order for it to look right (I think it's because macOS tries to restore the column width to its previous value).

Fixed version (this PR):
<img width="1202" alt="Screen Shot 2021-10-06 at 7 37 31 PM" src="https://user-images.githubusercontent.com/49624366/136297860-8fdfa0c1-2d2f-410b-b266-9ff7d086ee57.png">


